### PR TITLE
Update platinum-weather-card.ts

### DIFF
--- a/src/platinum-weather-card.ts
+++ b/src/platinum-weather-card.ts
@@ -1937,7 +1937,7 @@ export class PlatinumWeatherCard extends LitElement {
   }
 
   get iconRain(): string {
-    return `rainy-3`;
+    return `rainy-3-${this.dayOrNight}`;
   }
 
   get iconDust(): string {
@@ -1961,7 +1961,7 @@ export class PlatinumWeatherCard extends LitElement {
   }
 
   get iconHeavyShowers(): string {
-    return `rainy-2-${this.dayOrNight}`;
+    return `rainy-3`;
   }
 
   get iconCyclone(): string {


### PR DESCRIPTION
Associate "rainy" condition with an icon that seems less "rainy" than the icon associated with "pouring".  In particular, change the "pouring" icon to "rainy-3" without day or nighttime indicator, and change the "rainy" icon to "rainy-3-day" or "rainy-3-night", both of which include the sun or moon and seem less extremely rainy than the timeless icons.

(In any event, "pouring" should not be "rainy-2-day", which is in every way less rainy than "rainy-3".)